### PR TITLE
Move hosted repos from code to .wsgi file

### DIFF
--- a/ghooklistener/listener.py
+++ b/ghooklistener/listener.py
@@ -1,17 +1,18 @@
 import hmac
 import json
 
-from flask import Flask, request, Response
 from hashlib import sha1
 from http import HTTPStatus
 from typing import Callable, Optional, Dict, Any, Tuple
+
+from flask import Flask, request, Response
 
 
 PayloadType = Dict[str, Any]
 HandleFuncReturnType = Tuple[str, HTTPStatus]
 
 
-class Listener(object):
+class Listener:
 
     def __init__(self, name: str,
                  handlefunc: Callable[[PayloadType], HandleFuncReturnType],

--- a/handlers/cloner.py
+++ b/handlers/cloner.py
@@ -46,15 +46,14 @@ def pull(cloneloc: str, force: bool) -> bool:
         print(f"Invalid git directory: {cloneloc}")
         return False
 
-    p = sp.run(["git", "pull"],
-               stdout=sp.PIPE, stderr=sp.PIPE,
-               cwd=cloneloc, encoding="utf-8")
+    proc = sp.run(["git", "pull"],
+                  stdout=sp.PIPE, stderr=sp.PIPE, cwd=cloneloc, encoding="utf-8")
 
-    stdout, stderr = p.stdout.strip(), p.stderr.strip()
+    stdout, stderr = proc.stdout.strip(), proc.stderr.strip()
     print(f"Out: {stdout}")
     print(f"Err: {stderr}")
 
-    return not p.returncode
+    return not proc.returncode
 
 
 def create_app(repos_dir: str, secret_token: str, hosted_repos: List):
@@ -75,7 +74,7 @@ def main():
 
     if len(sys.argv) < 1 or not path.exists(sys.argv[1]):
         print("[Error] Provide git repositories directory as first argument")
-        exit(-1)
+        sys.exit(-1)
 
     repos_dir = sys.argv[1]
     if len(sys.argv) > 2:

--- a/handlers/cloner.py
+++ b/handlers/cloner.py
@@ -3,6 +3,7 @@ import subprocess as sp
 
 from http import HTTPStatus
 from os import path
+from typing import List
 
 from ghooklistener import Listener, PayloadType, HandleFuncReturnType
 
@@ -56,9 +57,9 @@ def pull(cloneloc: str, force: bool) -> bool:
     return not p.returncode
 
 
-def create_app(repos_dir: str, secret_token: str):
+def create_app(repos_dir: str, secret_token: str, hosted_repos: List):
     CONFIG['repos_dir'] = repos_dir
-    CONFIG['hosted_repos'] = ["odml-terminologies", "odml-templates"]
+    CONFIG['hosted_repos'] = hosted_repos
 
     print("Setting up listener for cloner handler")
     secret_token = secret_token.encode('utf-8')
@@ -70,6 +71,7 @@ def create_app(repos_dir: str, secret_token: str):
 def main():
     address = ":0"
     secret_token = b''
+    hosted_repos = []
 
     if len(sys.argv) < 1 or not path.exists(sys.argv[1]):
         print("[Error] Provide git repositories directory as first argument")
@@ -79,9 +81,11 @@ def main():
     if len(sys.argv) > 2:
         secret_token = sys.argv[2]
     if len(sys.argv) > 3:
-        address = sys.argv[3]
+        hosted_repos = [sys.argv[3]]
+    if len(sys.argv) > 4:
+        address = sys.argv[4]
 
-    listener = create_app(repos_dir, secret_token)
+    listener = create_app(repos_dir, secret_token, hosted_repos)
     listener.rundev(address)
 
 


### PR DESCRIPTION
The code changes move the hosted repos list from the `cloner.py` file to the corresponding `.wsgi` file. When now adding new hosted repositories, only the `.wsgi` file has to be updated. Closes issue #6.

The PR also does some minor PEP8 cleanup.
